### PR TITLE
fix: prevent information exposure in health endpoint

### DIFF
--- a/src/cyberpulse/api/routers/health.py
+++ b/src/cyberpulse/api/routers/health.py
@@ -27,12 +27,13 @@ async def health_check(db: Session = Depends(get_db)) -> dict:
     try:
         db.execute(text("SELECT 1"))
     except (SQLAlchemyError, DBAPIError) as e:
-        logger.warning(f"Database health check failed: {e}")
-        db_status = f"unhealthy: {e}"
+        # Log the full error for debugging, but don't expose to users
+        logger.warning(f"Database health check failed: {e}", exc_info=True)
+        db_status = "unhealthy"
     except Exception as e:
-        # Unexpected error - log at error level and re-raise
-        logger.error(f"Unexpected error during health check: {e}")
-        raise
+        # Unexpected error - log for debugging but return generic message
+        logger.error(f"Unexpected error during health check: {e}", exc_info=True)
+        db_status = "unhealthy"
 
     return {
         "status": "healthy" if db_status == "healthy" else "degraded",


### PR DESCRIPTION
## Summary

修复 GitHub Code scanning 安全警报：Information exposure through an exception

### 问题

`/health` 端点存在两个信息泄露风险：
1. 异常消息直接暴露给外部用户（可能包含数据库连接字符串等敏感信息）
2. 意外异常被重新抛出，可能暴露堆栈跟踪

### 修复

- 移除返回值中的异常详情，返回通用的 "unhealthy" 状态
- 添加 `exc_info=True` 记录完整错误信息用于调试
- 不再重新抛出异常，防止堆栈跟踪暴露

## Test Plan

- [x] `pytest tests/test_api/test_health_api.py` 通过（7 tests）