### PR TITLE
docs: add CLI usage manual for administrators

### DIFF
--- a/docs/cli-usage-manual.md
+++ b/docs/cli-usage-manual.md
@@ -28,7 +28,10 @@ cyberpulse version
 cyberpulse shell
 
 # 启动 API 服务器
-cyberpulse server [--host 0.0.0.0] [--port 8000]
+cyberpulse server start [--host 0.0.0.0] [--port 8000]
+
+# 查看 API 服务器状态
+cyberpulse server status
 ```
 
 ---


### PR DESCRIPTION
## Summary
- 添加管理员 CLI 使用手册 (`docs/cli-usage-manual.md`)
- 覆盖全部 7 个命令模块：source、job、content、client、config、log、diagnose
- 包含最佳实践、环境变量参考、错误码、ID 格式规范等附录

## Test Plan
- [ ] 文档格式正确，Markdown 渲染正常
- [ ] 命令示例可执行
- [ ] 附录信息准确

🤖 Generated with [Claude Code](https://claude.com/claude-code)