### PR TITLE
fix(security): address code review findings from PR #25

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     # ports:
     #   - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U cyberpulse -d cyberpulse"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-cyberpulse} -d cyberpulse"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/src/cyberpulse/services/base.py
+++ b/src/cyberpulse/services/base.py
@@ -98,9 +98,13 @@ def validate_url_for_ssrf(url: str, allow_localhost: bool = False) -> str:
 
     except socket.gaierror as e:
         raise SSRFError(f"Failed to resolve hostname: {hostname}") from e
+    except (socket.timeout, socket.herror, OSError) as e:
+        # Network/DNS errors - fail closed for security
+        raise SSRFError(f"DNS resolution error for {hostname}: {e}") from e
     except Exception as e:
-        logger.warning(f"Error during SSRF validation for {url}: {e}")
-        # Don't block on resolution errors, but log them
+        # Unexpected errors - fail closed to prevent SSRF bypass
+        logger.error(f"Unexpected error during SSRF validation for {url}: {e}")
+        raise SSRFError(f"SSRF validation failed for {url}") from e
 
     return url
 


### PR DESCRIPTION
## Summary

修复 PR #25 代码审查发现的问题。

## 修复内容

| 问题 | 修复 |
|------|------|
| SSRF 验证 DNS 解析失败时 bypass | 改为 fail closed，所有异常都抛出 SSRFError |
| docker-compose healthcheck 用户名硬编码 | 使用 `${POSTGRES_USER:-cyberpulse}` 环境变量 |

## 技术细节

### SSRF Fail Closed

```python
# Before: 意外异常时 URL 直接放行
except Exception as e:
    logger.warning(...)
    # URL passes through

# After: 所有异常都抛出 SSRFError
except (socket.timeout, socket.herror, OSError) as e:
    raise SSRFError(...)
except Exception as e:
    raise SSRFError(...)
```

### Docker Compose Healthcheck

```yaml
# Before
test: ["CMD-SHELL", "pg_isready -U cyberpulse -d cyberpulse"]

# After
test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-cyberpulse} -d cyberpulse"]
```

## Test plan

- [x] ruff check 通过
- [x] connector 测试通过 (134 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)