### PR TITLE
fix(ci): sanitize GITHUB_REF to prevent shell injection

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,12 +36,15 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
+          # Validate and sanitize GITHUB_REF
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+            # Sanitize: only allow alphanumeric, dots, and dashes
+            VERSION="${VERSION//[^a-zA-Z0-9.\-]/}"
           else
-            VERSION=latest
+            VERSION="latest"
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Building version: $VERSION"
 
       - name: Build and push


### PR DESCRIPTION
## Summary

- Quote all variables in shell script to prevent shell injection
- Add sanitization to only allow safe characters (alphanumeric, dots, dashes)
- Fixes CodeQL security warning

## Test Plan

- [x] Verify workflow syntax is valid
- [x] Merge after CodeQL check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)