### PR TITLE
feat(scripts): add cleanup options for test environment

### DIFF
--- a/scripts/cyber-pulse.sh
+++ b/scripts/cyber-pulse.sh
@@ -277,6 +277,17 @@ cmd_deploy() {
     if [[ "$use_local" == "true" ]]; then
         print_step "构建本地 Docker 镜像..."
         $DOCKER_COMPOSE $compose_files build
+
+        # 清理悬空镜像（构建产生的旧版本）
+        print_step "清理悬空镜像..."
+        local dangling_count
+        dangling_count=$(docker images --filter "dangling=true" -q 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "$dangling_count" -gt 0 ]]; then
+            docker image prune -f
+            print_success "已清理 $dangling_count 个悬空镜像"
+        else
+            print_success "无悬空镜像"
+        fi
     else
         print_step "拉取 Docker 镜像..."
         $DOCKER_COMPOSE $compose_files pull

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -21,6 +21,8 @@ API_URL="${API_URL:-http://localhost:8000}"
 OUTPUT_FILE=""
 KEEP_SOURCES=false
 DEBUG="${DEBUG:-false}"
+STOP_AFTER=false
+TEARDOWN_AFTER=false
 
 # ============================================================================
 # 日志函数
@@ -90,6 +92,14 @@ parse_args() {
                 KEEP_SOURCES=true
                 shift
                 ;;
+            --stop)
+                STOP_AFTER=true
+                shift
+                ;;
+            --teardown)
+                TEARDOWN_AFTER=true
+                shift
+                ;;
             --cleanup)
                 cleanup_verify_data
                 exit 0
@@ -101,6 +111,8 @@ parse_args() {
                 echo "  --output, -o FILE    输出报告到文件 (Markdown 格式)"
                 echo "  --sources, -s FILE   指定情报源清单 (默认: sources.yaml)"
                 echo "  --keep-sources       保留测试情报源"
+                echo "  --stop               验证成功后停止容器"
+                echo "  --teardown           验证成功后停止容器并清理镜像"
                 echo "  --cleanup            清理测试数据并退出"
                 echo "  --help, -h           显示此帮助"
                 echo ""
@@ -789,6 +801,47 @@ cleanup_verify_data() {
 }
 
 # ============================================================================
+# 基础设施清理
+# ============================================================================
+
+stop_containers() {
+    echo ""
+    echo "[停止容器]"
+
+    local project_root
+    project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+    if [ -f "$project_root/scripts/cyber-pulse.sh" ]; then
+        bash "$project_root/scripts/cyber-pulse.sh" stop
+    else
+        log_error "cyber-pulse.sh 未找到"
+        return 1
+    fi
+}
+
+teardown_infrastructure() {
+    echo ""
+    echo "[清理基础设施]"
+
+    # 停止容器
+    stop_containers
+
+    # 清理悬空镜像
+    echo ""
+    echo "清理悬空镜像..."
+    local dangling_images
+    dangling_images=$(docker images --filter "dangling=true" -q 2>/dev/null)
+    if [ -n "$dangling_images" ]; then
+        local count
+        count=$(echo "$dangling_images" | wc -l | tr -d ' ')
+        docker image prune -f
+        echo "  ✓ 已清理 $count 个悬空镜像"
+    else
+        echo "  ✓ 无悬空镜像"
+    fi
+}
+
+# ============================================================================
 # 报告输出
 # ============================================================================
 
@@ -935,6 +988,13 @@ main() {
     verify_level3
     cleanup_verify_data
     print_report
+
+    # 验证成功后清理基础设施
+    if [ "$TEARDOWN_AFTER" = "true" ]; then
+        teardown_infrastructure
+    elif [ "$STOP_AFTER" = "true" ]; then
+        stop_containers
+    fi
 
     # 释放锁
     if command -v flock &> /dev/null; then


### PR DESCRIPTION
## Summary

- **verify.sh**: 新增 `--stop` 和 `--teardown` 选项，验证成功后自动清理测试环境
- **cyber-pulse.sh**: 本地构建后自动清理悬空镜像，避免磁盘空间浪费

## Changes

### verify.sh

| 选项 | 功能 |
|------|------|
| `--stop` | 验证成功后停止容器 |
| `--teardown` | 停止容器 + 清理悬空镜像 |

### cyber-pulse.sh

- `deploy --local` 构建后自动执行 `docker image prune -f`

## Usage

```bash
# 验证后停止容器
./scripts/verify.sh --stop

# 验证后完整清理
./scripts/verify.sh --teardown

# 本地构建（自动清理悬空镜像）
./scripts/cyber-pulse.sh deploy --env test --local
```

## Test plan

- [x] `verify.sh --stop` 验证成功后停止容器
- [x] `verify.sh --teardown` 验证成功后停止容器并清理镜像
- [x] `cyber-pulse.sh deploy --local` 构建后清理悬空镜像
- [x] 帮助信息正确显示新选项

🤖 Generated with [Claude Code](https://claude.com/claude-code)