### PR TITLE
fix(scripts): improve error handling and consistency in verify.sh

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -824,18 +824,16 @@ teardown_infrastructure() {
     echo "[清理基础设施]"
 
     # 停止容器
-    stop_containers
+    stop_containers || return 1
 
     # 清理悬空镜像
     echo ""
     echo "清理悬空镜像..."
-    local dangling_images
-    dangling_images=$(docker images --filter "dangling=true" -q 2>/dev/null)
-    if [ -n "$dangling_images" ]; then
-        local count
-        count=$(echo "$dangling_images" | wc -l | tr -d ' ')
+    local dangling_count
+    dangling_count=$(docker images --filter "dangling=true" -q 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$dangling_count" -gt 0 ]; then
         docker image prune -f
-        echo "  ✓ 已清理 $count 个悬空镜像"
+        echo "  ✓ 已清理 $dangling_count 个悬空镜像"
     else
         echo "  ✓ 无悬空镜像"
     fi
@@ -991,9 +989,9 @@ main() {
 
     # 验证成功后清理基础设施
     if [ "$TEARDOWN_AFTER" = "true" ]; then
-        teardown_infrastructure
+        teardown_infrastructure || log_error "teardown_infrastructure 执行失败"
     elif [ "$STOP_AFTER" = "true" ]; then
-        stop_containers
+        stop_containers || log_error "stop_containers 执行失败"
     fi
 
     # 释放锁


### PR DESCRIPTION
## Summary

- 修复 `stop_containers` 和 `teardown_infrastructure` 返回值未检查的问题
- 修复 `teardown_infrastructure` 内部调用 `stop_containers` 未传播错误的问题
- 统一悬空镜像计数方法与 `cyber-pulse.sh` 保持一致

## Changes

```diff
# 错误处理
- teardown_infrastructure
+ teardown_infrastructure || log_error "teardown_infrastructure 执行失败"

- stop_containers  
+ stop_containers || log_error "stop_containers 执行失败"

# 函数内部错误传播
teardown_infrastructure() {
-   stop_containers
+   stop_containers || return 1
}

# 计数方法统一
- dangling_images=$(docker images --filter "dangling=true" -q)
- count=$(echo "$dangling_images" | wc -l)
+ dangling_count=$(docker images --filter "dangling=true" -q | wc -l | tr -d ' ')
```

## Test plan

- [x] Shell 语法检查通过
- [x] 验证测试 12/12 通过
- [x] `--stop` 和 `--teardown` 帮助输出正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)