### PR TITLE
fix(ci): add explicit permissions to workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,9 @@ env:
   NAMESPACE: cyberstrat-forge
   IMAGE_NAME: cyber-pulse
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- 添加 `permissions: contents: read` 到 docker-publish workflow
- 解决 GitHub Code scanning 告警：Workflow does not contain permissions
- 遵循最小权限原则

## Changes

```yaml
permissions:
  contents: read
```

**权限说明：**
- `contents: read` - checkout 代码所需的最小权限
- 显式声明避免使用默认的过高权限

## Test plan

- [x] YAML 语法验证通过
- [ ] GitHub Code scanning 告警消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)