### PR TITLE
fix(api): use dynamic version in health endpoint

### DIFF
--- a/src/cyberpulse/api/main.py
+++ b/src/cyberpulse/api/main.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from fastapi import FastAPI
 
 from ..config import settings
+from .. import __version__
 from .routers import content, sources, clients, health
 
 
@@ -61,7 +62,7 @@ setup_logging()
 app = FastAPI(
     title="cyber-pulse API",
     description="Security Intelligence Collection System",
-    version="0.1.0",
+    version=__version__,
     docs_url="/docs" if should_enable_docs() else None,
     redoc_url="/redoc" if should_enable_docs() else None,
     openapi_url="/openapi.json" if should_enable_docs() else None,

--- a/src/cyberpulse/api/routers/health.py
+++ b/src/cyberpulse/api/routers/health.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ...database import get_db
+from ... import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ async def health_check(db: Session = Depends(get_db)) -> dict:
 
     return {
         "status": "healthy" if db_status == "healthy" else "degraded",
-        "version": "0.1.0",
+        "version": __version__,
         "components": {
             "database": db_status,
             "api": "healthy",

--- a/tests/test_api/test_health_api.py
+++ b/tests/test_api/test_health_api.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from cyberpulse.api.main import app
 from cyberpulse.api.routers.health import get_db as health_get_db
+from cyberpulse import __version__
 
 
 @pytest.fixture
@@ -31,7 +32,7 @@ class TestHealthCheck:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "healthy"
-        assert data["version"] == "0.1.0"
+        assert data["version"] == __version__
         assert data["components"]["api"] == "healthy"
         assert data["components"]["database"] == "healthy"
 
@@ -68,7 +69,7 @@ class TestAppMetadata:
 
     def test_app_version(self):
         """Test that app has correct version."""
-        assert app.version == "0.1.0"
+        assert app.version == __version__
 
 
 class TestRouterRegistration:


### PR DESCRIPTION
## Summary

修复健康检查端点版本号硬编码问题，改为从 `__version__` 动态读取。

## 变更内容

| 文件 | 变更 |
|------|------|
| `src/cyberpulse/api/main.py` | 导入 `__version__`，FastAPI 应用版本使用动态值 |
| `src/cyberpulse/api/routers/health.py` | 导入 `__version__`，健康检查响应使用动态值 |
| `tests/test_api/test_health_api.py` | 测试用例使用 `__version__` 代替硬编码值 |

## 问题

之前健康检查端点返回的版本号是硬编码的 `"0.1.0"`，与实际版本 `1.3.0` 不一致。

## 解决方案

从 `cyberpulse.__version__` 导入版本号，确保版本一致性。

## Test plan

- [x] 运行 `uv run pytest tests/test_api/test_health_api.py -v` 通过
- [ ] 部署后验证 `/health` 端点返回正确版本号

🤖 Generated with [Claude Code](https://claude.com/claude-code)