### PR TITLE
fix(cli): ensure proper Chinese encoding in JSON output

### DIFF
--- a/src/cyberpulse/cli/commands/content.py
+++ b/src/cyberpulse/cli/commands/content.py
@@ -126,7 +126,7 @@ def list_content(
                 })
             # Use print() instead of console.print() to avoid Rich's line wrapping
             # which breaks JSON parsing
-            print(json.dumps(output, indent=2))
+            print(json.dumps(output, indent=2, ensure_ascii=False))
         else:
             table = Table(title=f"Content ({len(contents)} results)")
             table.add_column("Content ID", style="cyan", no_wrap=True)
@@ -219,7 +219,7 @@ def get_content(
                     "source_count": content.source_count,
                     "status": content.status.value if content.status else None,
                 }
-                print(json.dumps(output, indent=2))
+                print(json.dumps(output, indent=2, ensure_ascii=False))
         else:
             # List content matching filters
             since_dt = parse_datetime(since)
@@ -252,7 +252,7 @@ def get_content(
                     }
                     for content in contents
                 ]
-                console.print(json.dumps(output_list, indent=2))
+                console.print(json.dumps(output_list, indent=2, ensure_ascii=False))
 
     except typer.Exit:
         raise
@@ -286,7 +286,7 @@ def content_stats(
         stats = service.get_content_statistics()
 
         if format == "json":
-            print(json.dumps(stats, indent=2))
+            print(json.dumps(stats, indent=2, ensure_ascii=False))
         else:
             table = Table(title="Content Statistics", show_header=False)
             table.add_column("Metric", style="cyan")

--- a/src/cyberpulse/cli/commands/job.py
+++ b/src/cyberpulse/cli/commands/job.py
@@ -90,7 +90,7 @@ def list_jobs(
             for job in jobs:
                 if job.get("next_run_time"):
                     job["next_run_time"] = job["next_run_time"].isoformat()
-            print(json.dumps(jobs, indent=2))
+            print(json.dumps(jobs, indent=2, ensure_ascii=False))
             return
 
         # Create table for display
@@ -257,7 +257,7 @@ def job_status(
             # Convert datetime objects to ISO format
             if job.get("next_run_time"):
                 job["next_run_time"] = job["next_run_time"].isoformat()
-            console.print(json.dumps(job, indent=2))
+            console.print(json.dumps(job, indent=2, ensure_ascii=False))
             return
 
         # Display job details in a formatted way

--- a/src/cyberpulse/cli/commands/log.py
+++ b/src/cyberpulse/cli/commands/log.py
@@ -271,7 +271,7 @@ def error_logs(
 
     # JSON output
     if format == "json":
-        print(json.dumps(errors, indent=2))
+        print(json.dumps(errors, indent=2, ensure_ascii=False))
         raise typer.Exit(0)
 
     console.print(Panel(f"Found {len(errors)} error entries", style="red bold"))
@@ -347,7 +347,7 @@ def search_logs(
 
     # JSON output
     if format == "json":
-        print(json.dumps(matches, indent=2))
+        print(json.dumps(matches, indent=2, ensure_ascii=False))
         raise typer.Exit(0)
 
     console.print(Panel(f"Found {len(matches)} matches for '{text}'", style="blue bold"))

--- a/src/cyberpulse/cli/commands/source.py
+++ b/src/cyberpulse/cli/commands/source.py
@@ -122,7 +122,7 @@ def list_sources(
                 }
                 for s in sources
             ]
-            console.print(json.dumps({"sources": sources_data}, indent=2))
+            console.print(json.dumps({"sources": sources_data}, indent=2, ensure_ascii=False))
 
         else:
             # Table format (default)


### PR DESCRIPTION
## Summary

- Add `ensure_ascii=False` to all `json.dumps()` calls in CLI commands
- Fixes Chinese characters displaying as Unicode escape sequences (`\uXXXX`) in JSON output

## Affected commands

- `content get/list/stats --format json`
- `source list --format json`
- `job list/status --json`
- `log errors/search --format json`

## Test plan

- [ ] Run `cyber-pulse content get <content_id>` with Chinese content
- [ ] Verify Chinese characters display correctly instead of `\uXXXX`

🤖 Generated with [Claude Code](https://claude.com/claude-code)