### PR TITLE
fix(security): add SSRF validation to source quality validator

### DIFF
--- a/src/cyberpulse/api/startup.py
+++ b/src/cyberpulse/api/startup.py
@@ -64,7 +64,7 @@ def ensure_admin_client() -> None:
         print(f"\n{'='*60}")
         print("Admin client created successfully.")
         print(f"{'='*60}")
-        print(f"\n  Admin API Key: {plain_key}\n")
+        print(f"\n  Admin API Key: {plain_key}\n")  # nosec B105: intentional display for initial setup
         print("  IMPORTANT: This key is shown ONCE. Save it securely now!")
         print("  If lost, use './scripts/cyber-pulse.sh admin reset' to generate a new key.")
         print(f"\n{'='*60}\n")

--- a/src/cyberpulse/services/source_quality_validator.py
+++ b/src/cyberpulse/services/source_quality_validator.py
@@ -7,6 +7,8 @@ from typing import Any
 import feedparser
 import httpx
 
+from .base import SSRFError, validate_url_for_ssrf
+
 logger = logging.getLogger(__name__)
 
 
@@ -133,6 +135,13 @@ class SourceQualityValidator:
         Returns:
             List of sample items with content.
         """
+        # SSRF protection: validate URL before fetching
+        try:
+            validate_url_for_ssrf(feed_url)
+        except SSRFError as e:
+            logger.error(f"SSRF validation failed for {feed_url}: {e}")
+            return []
+
         try:
             async with httpx.AsyncClient(timeout=self.REQUEST_TIMEOUT) as client:
                 response = await client.get(feed_url, follow_redirects=True)


### PR DESCRIPTION
## Summary
- Add SSRF validation to `SourceQualityValidator._fetch_samples()` before fetching RSS feed samples
- Add `# nosec B105` comment for intentional Admin API Key display during initial setup

## Security
Fixes GitHub code scanning alert #11 (py/full-ssrf)

The `source_quality_validator.py` was directly fetching URLs without SSRF protection. Now uses the existing `validate_url_for_ssrf()` function to block requests to localhost, private IPs, and other dangerous destinations.

Alert #9 (py/clear-text-logging-sensitive-data) is intentionally ignored - displaying the initial Admin API Key to the operator is by design.

## Test Plan
- [ ] CodeQL scan passes without py/full-ssrf alert
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)