### PR TITLE
fix(security): add SSRF validation for redirect URLs

### DIFF
--- a/src/cyberpulse/services/source_quality_validator.py
+++ b/src/cyberpulse/services/source_quality_validator.py
@@ -145,6 +145,18 @@ class SourceQualityValidator:
         try:
             async with httpx.AsyncClient(timeout=self.REQUEST_TIMEOUT) as client:
                 response = await client.get(feed_url, follow_redirects=True)
+
+                # SSRF protection: validate final URL after redirects
+                final_url = str(response.url)
+                if final_url != feed_url:
+                    try:
+                        validate_url_for_ssrf(final_url)
+                    except SSRFError as e:
+                        logger.error(
+                            f"SSRF validation failed for redirect URL {final_url}: {e}"
+                        )
+                        return []
+
                 response.raise_for_status()
                 content = response.content
 


### PR DESCRIPTION
## Summary

- Fix SSRF vulnerability in `SourceQualityValidator._fetch_sample_items()`
- Add validation for final URL after HTTP redirects
- Align with `RSSConnector` implementation pattern

## Security Issue

GitHub Code Scanning Alert #11 identified a **Critical** SSRF vulnerability where `follow_redirects=True` was used without validating the redirect target URL. An attacker could exploit this by creating a URL that redirects to internal network resources.

## Fix

Added the same redirect validation pattern used in `RSSConnector`:
1. Capture final URL after redirects: `final_url = str(response.url)`
2. Validate final URL if different from original: `validate_url_for_ssrf(final_url)`
3. Return empty samples on validation failure

## Test Plan
- [ ] Code scanning alert #11 should be resolved after merge

Fixes GitHub Code Scanning Alert #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)