### PR TITLE
fix: resolve container status check and ENV_FILE path issues

### DIFF
--- a/deploy/backup/create-backup.sh
+++ b/deploy/backup/create-backup.sh
@@ -28,7 +28,7 @@ NC='\033[0m' # No Color
 # 默认配置
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEPLOY_DIR="$PROJECT_ROOT/deploy"
-ENV_FILE="$PROJECT_ROOT/.env"
+ENV_FILE="$PROJECT_ROOT/deploy/.env"
 BACKUPS_DIR="$PROJECT_ROOT/backups"
 COMPOSE_FILE="$DEPLOY_DIR/docker-compose.yml"
 DATA_DIR="$PROJECT_ROOT/data"
@@ -78,7 +78,7 @@ export_database() {
     cd "$DEPLOY_DIR"
 
     # 检查 PostgreSQL 容器是否运行
-    if ! $DOCKER_COMPOSE ps postgres 2>/dev/null | grep -q "running"; then
+    if ! $DOCKER_COMPOSE ps postgres 2>/dev/null | grep -q "Up"; then
         print_error "PostgreSQL 容器未运行"
         print_warning "请先启动服务: cyber-pulse.sh start"
         return 1

--- a/deploy/backup/restore-backup.sh
+++ b/deploy/backup/restore-backup.sh
@@ -28,7 +28,7 @@ NC='\033[0m' # No Color
 # 默认配置
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEPLOY_DIR="$PROJECT_ROOT/deploy"
-ENV_FILE="$PROJECT_ROOT/.env"
+ENV_FILE="$PROJECT_ROOT/deploy/.env"
 BACKUPS_DIR="$PROJECT_ROOT/backups"
 COMPOSE_FILE="$DEPLOY_DIR/docker-compose.yml"
 DATA_DIR="$PROJECT_ROOT/data"
@@ -174,7 +174,7 @@ restore_database() {
     cd "$DEPLOY_DIR"
 
     # 检查 PostgreSQL 容器是否运行
-    if ! $DOCKER_COMPOSE ps postgres 2>/dev/null | grep -q "running"; then
+    if ! $DOCKER_COMPOSE ps postgres 2>/dev/null | grep -q "Up"; then
         print_error "PostgreSQL 容器未运行"
         print_warning "请先启动服务: cyber-pulse.sh start"
         return 1

--- a/deploy/upgrade/create-snapshot.sh
+++ b/deploy/upgrade/create-snapshot.sh
@@ -25,7 +25,7 @@ NC='\033[0m' # No Color
 # 默认配置
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEPLOY_DIR="$PROJECT_ROOT/deploy"
-ENV_FILE="$PROJECT_ROOT/.env"
+ENV_FILE="$PROJECT_ROOT/deploy/.env"
 SNAPSHOTS_DIR="$PROJECT_ROOT/.snapshots"
 COMPOSE_FILE="$DEPLOY_DIR/docker-compose.yml"
 RETENTION_DAYS=7
@@ -74,7 +74,7 @@ export_database() {
     cd "$DEPLOY_DIR"
 
     # 检查 PostgreSQL 容器是否运行
-    if ! $DOCKER_COMPOSE ps postgres 2>/dev/null | grep -q "running"; then
+    if ! $DOCKER_COMPOSE ps postgres 2>/dev/null | grep -q "Up"; then
         print_error "PostgreSQL 容器未运行"
         return 1
     fi

--- a/deploy/upgrade/restore-snapshot.sh
+++ b/deploy/upgrade/restore-snapshot.sh
@@ -24,7 +24,7 @@ NC='\033[0m' # No Color
 # 默认配置
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEPLOY_DIR="$PROJECT_ROOT/deploy"
-ENV_FILE="$PROJECT_ROOT/.env"
+ENV_FILE="$PROJECT_ROOT/deploy/.env"
 SNAPSHOTS_DIR="$PROJECT_ROOT/.snapshots"
 COMPOSE_FILE="$DEPLOY_DIR/docker-compose.yml"
 
@@ -117,7 +117,7 @@ restore_database() {
     cd "$DEPLOY_DIR"
 
     # 检查 PostgreSQL 容器是否运行
-    if ! $DOCKER_COMPOSE ps postgres 2>/dev/null | grep -q "running"; then
+    if ! $DOCKER_COMPOSE ps postgres 2>/dev/null | grep -q "Up"; then
         print_error "PostgreSQL 容器未运行"
         return 1
     fi

--- a/scripts/cyber-pulse.sh
+++ b/scripts/cyber-pulse.sh
@@ -861,7 +861,7 @@ cmd_upgrade() {
 
     # 检查服务健康状态
     cd "$DEPLOY_DIR"
-    if ! $DOCKER_COMPOSE ps 2>/dev/null | grep -q "running"; then
+    if ! $DOCKER_COMPOSE ps 2>/dev/null | grep -q "Up"; then
         print_warning "服务未运行，建议先启动服务"
     fi
 
@@ -1008,7 +1008,7 @@ cmd_upgrade() {
 
         local healthy="true"
         for service in postgres redis api worker scheduler; do
-            if $DOCKER_COMPOSE ps "$service" 2>/dev/null | grep -q "running"; then
+            if $DOCKER_COMPOSE ps "$service" 2>/dev/null | grep -q "Up"; then
                 echo -e "  ${GREEN}[●]${NC} $service - 运行中"
             else
                 echo -e "  ${RED}[○]${NC} $service - 未运行"


### PR DESCRIPTION
## Summary
- Fix #102: 修复容器状态检查关键词错误 (`running` → `Up`)
- Fix #103: 修复 ENV_FILE 路径配置不一致 (`$PROJECT_ROOT/.env` → `$PROJECT_ROOT/deploy/.env`)

## Changes

### Issue #102: 容器状态检查关键词错误

Docker Compose v2 的 `docker compose ps` 输出格式为 `Up X minutes (healthy)`，脚本使用 `grep -q "running"` 导致误判服务未运行。

**修改文件**:
- `scripts/cyber-pulse.sh` (行 864, 1011)
- `deploy/backup/create-backup.sh` (行 81)
- `deploy/backup/restore-backup.sh` (行 177)
- `deploy/upgrade/create-snapshot.sh` (行 77)
- `deploy/upgrade/restore-snapshot.sh` (行 120)

### Issue #103: ENV_FILE 路径配置不一致

脚本中 `ENV_FILE` 指向错误路径，实际配置文件位于 `deploy/.env`。

**修改文件**:
- `deploy/backup/create-backup.sh` (行 31)
- `deploy/backup/restore-backup.sh` (行 31)
- `deploy/upgrade/create-snapshot.sh` (行 28)
- `deploy/upgrade/restore-snapshot.sh` (行 27)

## Test Plan
- [ ] 验证 `cyber-pulse.sh upgrade` 不再误报警告
- [ ] 验证 `create-backup.sh` 能正确备份 `.env`
- [ ] 验证 `restore-backup.sh` 能正确恢复 `.env`
- [ ] 验证 `create-snapshot.sh` 能正确创建快照
- [ ] 验证 `restore-snapshot.sh` 能正确恢复快照

Fixes #102
Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)