### PR TITLE
fix: avoid SIGPIPE false positive in upgrade pre-check (#109)

### DIFF
--- a/scripts/cyber-pulse.sh
+++ b/scripts/cyber-pulse.sh
@@ -861,9 +861,13 @@ cmd_upgrade() {
 
     # 检查服务健康状态
     cd "$DEPLOY_DIR"
+    # 临时禁用 pipefail 避免 SIGPIPE 误报
+    # 当 grep -q 找到匹配后退出，docker compose ps 仍在写入会触发 SIGPIPE
+    set +o pipefail
     if ! $DOCKER_COMPOSE ps 2>/dev/null | grep -q "Up"; then
         print_warning "服务未运行，建议先启动服务"
     fi
+    set -o pipefail
 
     # 2. 确定目标版本
     if [[ -z "$target_version" ]]; then


### PR DESCRIPTION
## Summary

- Fix #109: 升级脚本预检查在 pipefail 模式下误报"服务未运行"

### Root Cause

```
docker compose ps | grep -q "Up"
        │              │
        │              └─ 找到匹配后立即退出 (-q 模式)
        │
        └─ 仍在写入 → SIGPIPE (exit 141)
        
pipefail 模式 → 管道失败 → 误判"服务未运行"
```

### Fix

临时禁用 pipefail，避免 SIGPIPE 导致的误报：

```bash
set +o pipefail
if ! $DOCKER_COMPOSE ps 2>/dev/null | grep -q "Up"; then
    print_warning "服务未运行，建议先启动服务"
fi
set -o pipefail
```

### Test Plan

- [x] 服务运行时：正确检测到运行状态
- [x] 服务未运行时：正确检测到未运行状态
- [x] 脚本语法检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)