### PR TITLE
release: v1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-04-02
+
+### Fixed
+
+- Issue #109: 修复升级脚本预检查在 pipefail 模式下误报"服务未运行"
+  - 根因：`grep -q` 找到匹配后退出，`docker compose ps` 收到 SIGPIPE
+  - 修复：临时禁用 pipefail 进行管道检查
+  - 影响脚本：`cyber-pulse.sh` 第 864 行
+
 ## [1.8.2] - 2026-04-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cyber-pulse"
-version = "1.8.2"
+version = "1.8.3"
 description = "Cyber Pulse - Strategic Intelligence Collection System"
 readme = "README.md"
 authors = [{name = "老罗", email = "luoweirong@example.com"}]


### PR DESCRIPTION
## Summary

- 发布 v1.8.3 版本
- Fix #109: 升级脚本预检查在 pipefail 模式下误报"服务未运行"

### v1.8.3 内容

**Fixed:**
- Issue #109: 修复升级脚本预检查在 pipefail 模式下误报"服务未运行"
  - 根因：`grep -q` 找到匹配后退出，`docker compose ps` 收到 SIGPIPE
  - 修复：临时禁用 pipefail 进行管道检查

## Note

Tag `v1.8.3` 已推送，Docker 镜像构建已触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)