### PR TITLE
fix(ingestion): update next_ingest_at after successful collection

### DIFF
--- a/src/cyberpulse/tasks/ingestion_tasks.py
+++ b/src/cyberpulse/tasks/ingestion_tasks.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -137,6 +137,9 @@ def ingest_source(source_id: str, job_id: str | None = None) -> None:
         if not items_data:
             logger.info(f"No items fetched from source: {source.name}")
             source.last_ingested_at = datetime.now(UTC).replace(tzinfo=None)
+            # Update next_ingest_at based on schedule_interval
+            interval = source.schedule_interval or 14400  # Default 4 hours
+            source.next_ingest_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=interval)
             # Mark job as COMPLETED (no items is still a successful run)
             if job_id and job:
                 job.status = JobStatus.COMPLETED
@@ -203,6 +206,9 @@ def ingest_source(source_id: str, job_id: str | None = None) -> None:
 
         # Update source statistics
         source.last_ingested_at = datetime.now(UTC).replace(tzinfo=None)
+        # Update next_ingest_at based on schedule_interval
+        interval = source.schedule_interval or 14400  # Default 4 hours
+        source.next_ingest_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=interval)
         source.total_items = (source.total_items or 0) + len(new_items)
         db.commit()
 

--- a/src/cyberpulse/tasks/ingestion_tasks.py
+++ b/src/cyberpulse/tasks/ingestion_tasks.py
@@ -136,14 +136,29 @@ def ingest_source(source_id: str, job_id: str | None = None) -> None:
 
         if not items_data:
             logger.info(f"No items fetched from source: {source.name}")
-            source.last_ingested_at = datetime.now(UTC).replace(tzinfo=None)
-            # Update next_ingest_at based on schedule_interval
-            interval = source.schedule_interval or 14400  # Default 4 hours
-            source.next_ingest_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=interval)
+            # Use single timestamp for consistency
+            now = datetime.now(UTC).replace(tzinfo=None)
+            source.last_ingested_at = now
+            # Validate interval with defensive minimum
+            raw_interval = source.schedule_interval
+            if raw_interval is None:
+                interval = 14400  # Default 4 hours
+            elif raw_interval < 300:
+                logger.warning(
+                    f"Invalid schedule_interval for {source_id}: "
+                    f"{raw_interval}s, using minimum 300s"
+                )
+                interval = 300
+            else:
+                interval = raw_interval
+            source.next_ingest_at = now + timedelta(seconds=interval)
+            logger.debug(
+                f"Updated next_ingest_at for source {source_id}: interval={interval}s"
+            )
             # Mark job as COMPLETED (no items is still a successful run)
             if job_id and job:
                 job.status = JobStatus.COMPLETED
-                job.completed_at = datetime.now(UTC).replace(tzinfo=None)
+                job.completed_at = now
                 job.result = {"new_items": 0, "duplicates": 0, "failed": 0}
             db.commit()
             return
@@ -205,10 +220,25 @@ def ingest_source(source_id: str, job_id: str | None = None) -> None:
                 raise
 
         # Update source statistics
-        source.last_ingested_at = datetime.now(UTC).replace(tzinfo=None)
-        # Update next_ingest_at based on schedule_interval
-        interval = source.schedule_interval or 14400  # Default 4 hours
-        source.next_ingest_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=interval)
+        # Use single timestamp for consistency
+        now = datetime.now(UTC).replace(tzinfo=None)
+        source.last_ingested_at = now
+        # Validate interval with defensive minimum
+        raw_interval = source.schedule_interval
+        if raw_interval is None:
+            interval = 14400  # Default 4 hours
+        elif raw_interval < 300:
+            logger.warning(
+                f"Invalid schedule_interval for {source_id}: "
+                f"{raw_interval}s, using minimum 300s"
+            )
+            interval = 300
+        else:
+            interval = raw_interval
+        source.next_ingest_at = now + timedelta(seconds=interval)
+        logger.debug(
+            f"Updated next_ingest_at for source {source_id}: interval={interval}s"
+        )
         source.total_items = (source.total_items or 0) + len(new_items)
         db.commit()
 


### PR DESCRIPTION
## Summary

修复 `next_ingest_at` 字段在采集完成后没有更新的问题。

## Problem

采集任务完成后，`next_ingest_at` 字段没有被正确更新，导致：
- UI 显示情报源为 "OVERDUE" 状态
- `next_ingest_at` 时间是过去的旧值

## Changes

- 导入 `timedelta` 模块
- 在采集成功后更新 `next_ingest_at = now + schedule_interval`
- 处理两种情况：有 items 和无 items 时都更新

## Technical Details

修改文件：`src/cyberpulse/tasks/ingestion_tasks.py`

- 第 5 行：添加 `timedelta` 导入
- 第 140-142 行：无 items 时更新 `next_ingest_at`
- 第 209-211 行：有 items 时更新 `next_ingest_at`

默认间隔为 14400 秒（4 小时），如果 `schedule_interval` 未设置。

## Test Plan

- [ ] 验证采集任务完成后 `next_ingest_at` 正确更新
- [ ] 验证 UI 显示不再显示 OVERDUE 状态
- [ ] 验证 Scheduler 调度不受影响（仍正常工作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)