### PR TITLE
release: v1.10.2 - Fix next_ingest_at update after collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-05-27
+
+### Fixed
+
+- `next_ingest_at` 字段在采集完成后正确更新 (#122)
+  - 修复采集任务完成后 `next_ingest_at` 未更新的 bug
+  - 添加 `schedule_interval` 防御性验证（最小值 300 秒）
+  - 使用单一时间基准确保 `last_ingested_at` 和 `next_ingest_at` 一致
+  - 添加 DEBUG/WARNING 日志便于调试调度问题
+
 ## [1.10.1] - 2026-04-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cyber-pulse"
-version = "1.9.0"
+version = "1.10.2"
 description = "Cyber Pulse - Strategic Intelligence Collection System"
 readme = "README.md"
 authors = [{name = "老罗", email = "luoweirong@example.com"}]


### PR DESCRIPTION
## Summary

发布 v1.10.2 版本，包含 next_ingest_at 修复。

## Changes

- 更新版本号：1.9.0 → 1.10.2
- 更新 CHANGELOG.md 添加 v1.10.2 记录

## v1.10.2 Changes

### Fixed

- `next_ingest_at` 字段在采集完成后正确更新 (#122)
  - 修复采集任务完成后 `next_ingest_at` 未更新的 bug
  - 添加 `schedule_interval` 防御性验证（最小值 300 秒）
  - 使用单一时间基准确保 `last_ingested_at` 和 `next_ingest_at` 一致
  - 添加 DEBUG/WARNING 日志便于调试调度问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)